### PR TITLE
Removed Samsung's arbitrary adapter check

### DIFF
--- a/drivers/video/fbdev/exynos/dpu20/displayport_drv.c
+++ b/drivers/video/fbdev/exynos/dpu20/displayport_drv.c
@@ -2622,31 +2622,6 @@ static void displayport_aux_sel(struct displayport_device *displayport)
 	}
 }
 
-static void displayport_check_adapter_type(struct displayport_device *displayport)
-{
-	displayport->dex_adapter_type = DEX_FHD_SUPPORT;
-
-	if (displayport->ven_id != 0x04e8)
-		return;
-
-	switch(displayport->prod_id) {
-	case 0xa029: /* PAD */
-	case 0xa020: /* Station */
-	case 0xa02a:
-	case 0xa02b:
-	case 0xa02c:
-	case 0xa02d:
-	case 0xa02e:
-	case 0xa02f:
-	case 0xa030:
-	case 0xa031:
-	case 0xa032:
-	case 0xa033:
-		displayport->dex_adapter_type = DEX_WQHD_SUPPORT;
-		break;
-	};
-}
-
 static int usb_typec_displayport_notification(struct notifier_block *nb,
 		unsigned long action, void *data)
 {
@@ -2690,7 +2665,7 @@ static int usb_typec_displayport_notification(struct notifier_block *nb,
 			displayport_info("CCIC_NOTIFY_ID_DP_CONNECT, %x\n", usb_typec_info.sub1);
 			displayport->ven_id = usb_typec_info.sub2;
 			displayport->prod_id = usb_typec_info.sub3;
-			displayport_check_adapter_type(displayport);
+			displayport->dex_adapter_type = DEX_WQHD_SUPPORT;
 			displayport_info("VID:0x%llX, PID:0x%llX\n", displayport->ven_id, displayport->prod_id);
 #ifdef CONFIG_SEC_DISPLAYPORT_BIGDATA
 			secdp_bigdata_connection();


### PR DESCRIPTION
There is no need to limit resolution on non-samsung branded adapters for dex mode.